### PR TITLE
Don't build unused PIC object code

### DIFF
--- a/mp4v2/configure.ac
+++ b/mp4v2/configure.ac
@@ -81,7 +81,7 @@ AC_ARG_ENABLE([mingw_mt],
 
 AC_PROG_CXX
 AC_LIBTOOL_WIN32_DLL
-AC_PROG_LIBTOOL
+LT_INIT(disable-shared)
 
 AC_CHECK_PROG([FOUND_HELP2MAN],[help2man],[yes],[no])
 


### PR DESCRIPTION
Should actually twice the encoding speed.