### PR TITLE
Change argument type to ‘long unsigned int’

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,11 +141,11 @@ void averageTimecode(Option &opt)
         double average = static_cast<double>(sum) / kk->size();
         opt.averages.push_back(std::make_pair(kk->size(), average));
     }
-    std::fprintf(stderr, "Divided into %lu group%s\n",
-            groups.size(), (groups.size() == 1) ? "" : "s");
+    std::fprintf(stderr, "Divided into %d group%s\n",
+            int(groups.size()), (groups.size() == 1) ? "" : "s");
     for (size_t i = 0; i < opt.averages.size(); ++i) {
-        std::fprintf(stderr, "%lu frames: time delta %g\n",
-                opt.averages[i].first, opt.averages[i].second);
+        std::fprintf(stderr, "%d frames: time delta %g\n",
+                int(opt.averages[i].first), opt.averages[i].second);
     }
 
     tc.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,10 +141,10 @@ void averageTimecode(Option &opt)
         double average = static_cast<double>(sum) / kk->size();
         opt.averages.push_back(std::make_pair(kk->size(), average));
     }
-    std::fprintf(stderr, "Divided into %d group%s\n",
+    std::fprintf(stderr, "Divided into %lu group%s\n",
             groups.size(), (groups.size() == 1) ? "" : "s");
     for (size_t i = 0; i < opt.averages.size(); ++i) {
-        std::fprintf(stderr, "%d frames: time delta %g\n",
+        std::fprintf(stderr, "%lu frames: time delta %g\n",
                 opt.averages[i].first, opt.averages[i].second);
     }
 


### PR DESCRIPTION
Silences this warning (appears 2 times):
`warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]`