### PR TITLE
fix compilation errors and warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <sstream>
 #include <numeric>
+#include <algorithm>
 #if defined(_WIN32)
 #include <windows.h>
 #include "utf8_codecvt_facet.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -395,7 +395,7 @@ int main1(int argc, char **argv)
                 int nframes, num, denom = 1;
                 if (std::sscanf(optarg, "%d:%d/%d", &nframes, &num, &denom) < 2)
                     usage();
-                FPSRange range = { nframes, num, denom };
+                FPSRange range = { (uint32_t)nframes, num, denom };
                 option.ranges.push_back(range);
             } else if (ch == 'p') {
                 option.printOnly = true;


### PR DESCRIPTION
1. #include <algorithm> to fix compilation errors in VC++ 2015:

    error C2039: 'max': is not a member of 'std'
    error C2039: 'min': is not a member of 'std'

2. Fix a compilation warning.